### PR TITLE
Update .gitignore to exclude memory.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ Thumbs.db
 *.exe
 *.dll
 *.pak
+memory.json


### PR DESCRIPTION
Description:
This PR updates the .gitignore file to prevent memory.json from being tracked by Git.
This file is either temporary, environment-specific, or not relevant for version control and should not be committed.

Why:
To avoid accidental commits of local or sensitive data and keep the repo clean.
